### PR TITLE
Add question mark to ignored punctuation

### DIFF
--- a/src/utils/text-filters.ts
+++ b/src/utils/text-filters.ts
@@ -50,7 +50,7 @@ function filterNFC(str: string) {
 }
 
 function filterPunctuation(str: string) {
-    return str.replaceAll(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, "");
+    return str.replaceAll(/[.,\/#!?$%\^&\*;:{}=\-_`~()]/g, "");
 }
 
 function filterCaps(str: string) {


### PR DESCRIPTION
I tested this using a locally-running version of the app and verified that question marks are now ignored when "Ignore Punctuation" is selected.

fixes #100 