### PR TITLE
Add option to not reverse new two-sided cards until after initial study

### DIFF
--- a/src/core/flashcard-entry.ts
+++ b/src/core/flashcard-entry.ts
@@ -48,7 +48,7 @@ export abstract class FlashcardType<E, D, S> {
     }
 
     abstract preprocessEntry(entry: E, settings: S): void;
-    abstract processEntry(entry: E, settings: S): Promise<D>;
+    abstract processEntry(entry: E, settings: S, context: any): Promise<D>;
     abstract getSearchableText(entry: E): string;
     abstract getSpeakableText(data: D): string;
     abstract generateCard(data: D, settings: S): Flashcard;
@@ -102,9 +102,10 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         return;
     }
 
-    // abstract processEntry(entry: E, settings: S): Promise<D>;
-    processEntry(entry: SimpleCardEntry, settings: SimpleCardSettings): Promise<SimpleCardData> {
-        var reversed = entry.twoSided && (Math.random() < 0.5);
+    // abstract processEntry(entry: E, settings: S, context: any): Promise<D>;
+    processEntry(entry: SimpleCardEntry, settings: SimpleCardSettings, context: any): Promise<SimpleCardData> {
+        var preventReversedCard = context.preventReversedCard;
+        var reversed = !preventReversedCard && entry.twoSided && (Math.random() < 0.5);
         var spoken = reversed && (Math.random() < 0.5);
 
         var subber = makeSubber(settings.substitutions);
@@ -325,8 +326,8 @@ export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, 
         this.cache.addKey(entry.key, (k) => this.fetchCloze(entry.key, settings));
     }
 
-    // abstract processEntry(entry: E, settings: S): Promise<D>;
-    processEntry(entry: ClozeCardEntry, settings: ClozeCardSettings): Promise<ClozeCardData> {
+    // abstract processEntry(entry: E, settings: S, context: any): Promise<D>;
+    processEntry(entry: ClozeCardEntry, settings: ClozeCardSettings, context: any): Promise<ClozeCardData> {
         return this.cache.getKey(
             entry.key,
             (k) => this.fetchCloze(entry.key, settings)    

--- a/src/decks/spaced-repetition-modular.ts
+++ b/src/decks/spaced-repetition-modular.ts
@@ -86,6 +86,7 @@ export type SRModularSettings = {
     incorrectFactor: number,
     inactiveTags: string[],
     readCorrectAnswers: boolean,
+    preventReversedNewCards: boolean,
     speechSettings: SpeechSettings,
     filterSettings: TextFilterSettings
 }
@@ -97,6 +98,7 @@ export const defaultSRModularSettings = {
     incorrectFactor: 0.5,
     inactiveTags: [],
     readCorrectAnswers: false,
+    preventReversedNewCards: false,
     speechSettings: defaultSpeechSettings(),
     filterSettings: defaultTextFilterSettings
 }
@@ -234,12 +236,12 @@ export class ModularSpacedRepGen
         card: SpacedRepCardPhysical<SRModularContent, SRModularAuxData>,
         st: SpacedRepState<SRModularContent, SRModularAuxData, SRModularSettings>
     ): Promise<SpacedRepCardPhysical<SRModularContent, SRModularAuxData>> {
-        if (card.data === undefined)
-            return trivialPromise(card);
+        if (card.data === undefined) { return trivialPromise(card); }
 
         var cardType = card.data!.content.cardType;
         var cardEntry = card.data!.content.cardEntry;
-        var dp = gCardTypeRegistry[cardType].processEntry(cardEntry, st.settings.cardTypeSettings[cardType]);
+        var context = { preventReversedCard: card.data!.intervalMinutes == 0 && st.settings.preventReversedNewCards };
+        var dp = gCardTypeRegistry[cardType].processEntry(cardEntry, st.settings.cardTypeSettings[cardType], context);
     
         return dp.then((d) => {
             card.data!.content.cardData = d;
@@ -290,6 +292,8 @@ export class ModularSpacedRepGen
         var speechDiv = document.createElement("div");
         speechDiv.appendChild(speechCheckbox.element);
         speechDiv.appendChild(speechEditor.element);
+
+        var preventReversedNewCardsCheckbox = boolEditor("Don't reverse two-sided cards during initial study", st.settings.preventReversedNewCards);
 
         var omitTagsEditor = singleTextFieldEditor(st.settings.inactiveTags.join(','));
         (<HTMLInputElement>omitTagsEditor.element).placeholder = "comma-separated tags...";
@@ -429,6 +433,7 @@ export class ModularSpacedRepGen
             correctFactor.element,
             incorrectFactor.element,
             omitTagsCont,
+            preventReversedNewCardsCheckbox.element,
             speechDiv,
             filterEditor.element
         ].concat(cardEditorGroups.map((ed) => ed.element)).map((el) => {
@@ -446,6 +451,7 @@ export class ModularSpacedRepGen
                     correctFactor: correctFactor.menuToState(),
                     incorrectFactor: incorrectFactor.menuToState(),
                     readCorrectAnswers: speechCheckbox.menuToState(),
+                    preventReversedNewCards: preventReversedNewCardsCheckbox.menuToState(),
                     speechSettings: speechEditor.menuToState(),
                     filterSettings: filterEditor.menuToState(),
                     inactiveTags: omitTagsEditor.menuToState().split(",")


### PR DESCRIPTION
Now when you make a new two-sided card, you have the option of waiting until the card moves out of "new" status to start reversing.

closes #103 