### PR TITLE
several new features (SR card HTML templates, adjustable card reversal probs, etc.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,12 @@ clean:
 	rm -rf dist/*
 
 docs: clean
+	mkdir -p dist
 	mkdir dist/docs
 	./build_docs
 
 build: docs 
+	mkdir -p dist
 	tsc --target es2022
 	cp src/*.html dist/
 	cp src/static/style/*.css dist/

--- a/docs/help.md
+++ b/docs/help.md
@@ -9,10 +9,6 @@ title: Flashcards help
 - Press `Up Arrow` to mark a card as correct, overriding a previous incorrect answer.
 - Press `Down Arrow` to skip a card and receive a new one, ignoring any previous answer.
 
-In the spaced repetition deck:
-
-- Press `Shift + Right Arrow` to swap the source and target text boxes of a card in the menu.
-
 # Types of decks
 
 ## Key-value quiz deck
@@ -21,7 +17,9 @@ Each card in the deck has a prompt and a correct answer. Cards are chosen and di
 
 ## Spaced repetition deck
 
-This deck uses the *spaced repetition* algorithm to help you study cards long-term.
+This deck uses the *spaced repetition* algorithm to help you study cards long-term. It also offers several detailed options for customization and different types of cards.
+
+### Spaced repetition algorithm
 
 Each time you answer a card correctly, it is removed from the queue and its due date is set for a later date and time. The amount of time between the time a card is answered correctly and its next due date is called that card's *interval*. When a card is answered correctly, its interval is multiplied by the *correct factor* $\alpha^+ > 1$, and when it is answered incorrectly, its interval is multiplied by the *incorrect factor* $\alpha^- < 1$. This way, when cards are answered correctly, they come due less often, and when they are answered incorrectly, they come due more often.
 
@@ -36,6 +34,30 @@ The configurable parameters for the deck are as follows:
 - Incorrect factor: the factor $\alpha^-$ by which a card's interval increases when answered incorrectly
 - Probability of review cards: when studying due cards, the probability that each card is taken from review cards
 
-## Cloze spaced repetition deck
+### Types of cards
 
-TODO.
+There are currently two types of available cards for the spaced repetition deck.
+
+Firstly, there are the **simple two-sided cards**. These cards each have a *prompt* and an *answer*. Multiple possible answers can be listed in the answer text field, separated by the pipe `|` character, and any one of them will be accepted as correct. There are also options allowing these cards to be *reversed*, in which case the user will be presented with the card's second field and required to enter the value of its first field, and *spoken and reversed*, in which case the user will be presented with an audio button that reads aloud the card's second field.
+
+The following data is passed to templates of this card type:
+
+- `prompts`: a list of possible prompts for the card
+- `reversed`: a boolean indicating whether the card is reversed
+- `spoken`: a boolean indicating whether the (reversed) card uses an audio prompt
+- `fontSize`: a suggested font size for the card text
+- `cardsLeft`: the number of cards left to study
+- `isPractice`: a boolean indicating whether the card is just a practice card
+
+Secondly, there are the **cloze puzzle cards**. These cards depend on an external cloze puzzle server to generate puzzles for given words. The user must supply a server URL, a source language code, a target language code, and (optionally) a list of puzzle tags determining subsets of the total set of puzzles that are desired. Each card entry should consist of a word (in its base form) in the target language. When studying a card, a fill-in-the-blank puzzle involving that word will be generated.
+
+The following data is passed to templates of this card type:
+
+- `key`: the target word from the card entry
+- `puzzleFound`: a boolean indicating whether a puzzle was found for that word on the server
+- `prompt`: the prompt of the puzzle, i.e. a sentence in the target language with a word missing
+- `translation`: a translation of the target sentence in the source language
+- `source`: the name of the puzzle group from which the puzzle is taken 
+- `fontSize`: a suggested font size for the card text
+- `cardsLeft`: the number of cards left to study
+- `isPractice`: a boolean indicating whether the card is just a practice card

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@svgmoji/openmoji": "^3.2.0",
+        "@types/nunjucks": "^3.2.6",
+        "ace-builds": "^1.43.4",
+        "ace-code-editor": "^1.2.3",
         "assert": "^2.1.0",
+        "brace": "^0.11.1",
+        "braces": "^3.0.3",
         "buffer": "^6.0.3",
         "csv-parse": "^5.6.0",
         "emoji-js": "^3.8.1",
@@ -28,6 +33,7 @@
         "glslify": "^7.1.1",
         "lambert-w-function": "^3.0.0",
         "mapbox-gl": "^1.13.3",
+        "nunjucks": "^3.2.4",
         "openmoji": "^15.1.0",
         "papaparse": "^5.4.1",
         "plotly": "^1.0.6",
@@ -41,6 +47,7 @@
         "uuid-by-string": "^4.0.0"
       },
       "devDependencies": {
+        "@types/ace": "^0.0.52",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.2",
         "@types/plotly.js": "^2.35.1",
@@ -2420,6 +2427,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/ace": {
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/@types/ace/-/ace-0.0.52.tgz",
+      "integrity": "sha512-YPF9S7fzpuyrxru+sG/rrTpZkC6gpHBPF14W3x70kqVOD+ks6jkYLapk4yceh36xej7K4HYxcyz9ZDQ2lTvwgQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2690,6 +2704,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
+      "license": "MIT"
     },
     "node_modules/@types/pbf": {
       "version": "3.0.5",
@@ -3292,6 +3312,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+      "license": "MIT"
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -3321,6 +3347,28 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/ace-builds": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.4.tgz",
+      "integrity": "sha512-8hAxVfo2ImICd69BWlZwZlxe9rxDGDjuUhh+WeWgGDvfBCE+r3lkynkQvIovDz4jcMi8O7bsEaFygaDT+h9sBA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ace-code-editor": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ace-code-editor/-/ace-code-editor-1.2.3.tgz",
+      "integrity": "sha512-KLuqtC2Y+3h2J1RlI2S89EWN8aRDrJlY7d1FzvjDxlog8X3HS79zKml11KcuJAdKQ0U8qiZe+oH8Y/UbGAe2Eg==",
+      "dependencies": {
+        "mime": "1.2.x"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/ace-code-editor/node_modules/mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha512-Ysa2F/nqTNGHhhm9MV8ure4+Hc+Y8AWiqUdHxsO7xu8zc92ND9f3kpALHjaP026Ft17UfxrMt95c50PLUeynBw=="
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -3468,7 +3516,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3548,6 +3596,12 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
       "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
     "node_modules/assert": {
@@ -3732,7 +3786,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3845,6 +3899,12 @@
         "multicast-dns": "^7.2.5"
       }
     },
+    "node_modules/brace": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/brace/-/brace-0.11.1.tgz",
+      "integrity": "sha512-Fc8Ne62jJlKHiG/ajlonC4Sd66Pq68fFwK4ihJGNZpGqboc324SQk+lRvMzpPRuJOmfrJefdG8/7JdWX4bzJ2Q==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -3859,7 +3919,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4119,7 +4178,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -5748,7 +5807,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6228,7 +6286,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -6913,7 +6971,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -6975,7 +7033,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7043,7 +7101,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7119,7 +7177,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8887,7 +8944,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8922,6 +8979,40 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nunjucks/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-assign": {
@@ -9299,7 +9390,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9762,7 +9853,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -11112,7 +11203,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
   "description": "",
   "dependencies": {
     "@svgmoji/openmoji": "^3.2.0",
+    "@types/nunjucks": "^3.2.6",
+    "ace-builds": "^1.43.4",
+    "ace-code-editor": "^1.2.3",
     "assert": "^2.1.0",
+    "brace": "^0.11.1",
+    "braces": "^3.0.3",
     "buffer": "^6.0.3",
     "csv-parse": "^5.6.0",
     "emoji-js": "^3.8.1",
@@ -30,6 +35,7 @@
     "glslify": "^7.1.1",
     "lambert-w-function": "^3.0.0",
     "mapbox-gl": "^1.13.3",
+    "nunjucks": "^3.2.4",
     "openmoji": "^15.1.0",
     "papaparse": "^5.4.1",
     "plotly": "^1.0.6",
@@ -43,6 +49,7 @@
     "uuid-by-string": "^4.0.0"
   },
   "devDependencies": {
+    "@types/ace": "^0.0.52",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.2",
     "@types/plotly.js": "^2.35.1",

--- a/src/core/editor.ts
+++ b/src/core/editor.ts
@@ -4,6 +4,8 @@ import {
     guidGenerator
 } from "utils/utils"
 
+import * as ace from 'brace';
+
 export type StateEditor<s> = {
     element: HTMLElement,
     menuToState: () => s
@@ -121,6 +123,28 @@ export function doubleTextFieldEditor(txts: [string, string]): StateEditor<[stri
     editor.element.appendChild(children[0].element);
     editor.element.appendChild(children[1].element);
     return editor;
+}
+
+export function htmlEditor(content: string): StateEditor<string> {
+    var htmlEd = document.createElement("div");
+    var ed = ace.edit(htmlEd);
+    ed.setValue(content);
+    htmlEd.style.height = "100px";
+    htmlEd.style.width = "70%";
+    return {
+        element: htmlEd,
+        menuToState: () => ed.getValue()
+    }
+}
+
+export function textAreaEditor(txt: string): StateEditor<string> {
+    var textarea = document.createElement("textarea");
+    textarea.classList.add("menu-textarea");
+    textarea.value = txt;
+    return {
+        element: textarea,
+        menuToState: () => textarea.value
+    };
 }
 
 export function optionsEditor<a>(st: a, opts: a[], labels: (x: a) => string): StateEditor<a> {

--- a/src/core/editor.ts
+++ b/src/core/editor.ts
@@ -129,8 +129,8 @@ export function htmlEditor(content: string): StateEditor<string> {
     var htmlEd = document.createElement("div");
     var ed = ace.edit(htmlEd);
     ed.setValue(content);
-    htmlEd.style.height = "100px";
-    htmlEd.style.width = "70%";
+    htmlEd.style.height = "200px";
+    htmlEd.style.width = "90%";
     return {
         element: htmlEd,
         menuToState: () => ed.getValue()

--- a/src/core/flashcard-deck.ts
+++ b/src/core/flashcard-deck.ts
@@ -122,7 +122,7 @@ function importExportSetup<S>(deckSlug: string, setDeck: (s: S) => void) {
     }
 
     exportBtn.onclick = (e) => {
-        downloadText(deckSlug, JSON.stringify(gDeckRegistry[deckSlug])); 
+        downloadText(deckSlug, JSON.stringify(gDeckRegistry[deckSlug], null, "\t")); 
     } 
 }
 

--- a/src/core/flashcard-entry.ts
+++ b/src/core/flashcard-entry.ts
@@ -13,7 +13,8 @@ import {
     multipleEditors,
     doubleTextFieldEditor,
     textAreaEditor,
-    htmlEditor
+    htmlEditor,
+    scrollNumberEditor
 } from "core/editor"
 import {
     TextFilterSettings,
@@ -114,6 +115,8 @@ export type SimpleCardData = {
 export type SimpleCardSettings = {
     doTwoSided: boolean,
     doReadAloud: boolean,
+    probReversed: number,
+    probSpoken: number,
     speechSettings: SpeechSettings,
     substitutions: [string, string][],
     template: string
@@ -135,9 +138,9 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
     // abstract processEntry(entry: E, settings: S, context: any): Promise<D>;
     processEntry(entry: SimpleCardEntry, settings: SimpleCardSettings, context: any): Promise<SimpleCardData> {
         var preventReversedCard = context.preventReversedCard;
-        var reversed = !preventReversedCard && entry.twoSided && (Math.random() < 0.5);
+        var reversed = !preventReversedCard && entry.twoSided && (Math.random() < settings.probReversed);
         var canBeSpoken = settings.doReadAloud && entry.readAloud;
-        var spoken = reversed && canBeSpoken && (Math.random() < 0.5);
+        var spoken = reversed && canBeSpoken && (Math.random() < settings.probSpoken);
 
         var subber = makeSubber(settings.substitutions);
         var tpPrompt = [];
@@ -248,15 +251,25 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
     makeSettingsEditor(settings: SimpleCardSettings): StateEditor<SimpleCardSettings> {
         var contDiv = document.createElement("div");
 
+        var reverseDetails = document.createElement("details");
+        var reverseSummary = document.createElement("summary");
+        reverseSummary.textContent = "Two-sided card settings";
+        contDiv.appendChild(reverseDetails);
+        reverseDetails.appendChild(reverseSummary);
         var twoSidedEditor = boolEditor("Study both sides of two-sided cards?", settings.doTwoSided);
         var twoSidedCont = document.createElement("div");
         twoSidedCont.appendChild(twoSidedEditor.element);
-        contDiv.appendChild(twoSidedCont);
+        reverseDetails.appendChild(twoSidedCont);
 
         var readAloudEditor = boolEditor("Read aloud two-sided cards with setting enabled?", settings.doReadAloud);
         var readAloudCont = document.createElement("div");
         readAloudCont.appendChild(readAloudEditor.element);
-        contDiv.appendChild(readAloudCont);
+        reverseDetails.appendChild(readAloudCont);
+
+        var pReversedEditor = scrollNumberEditor("Probability of card being reversed", settings.probReversed, 0.1, 0.9, 0.1);
+        var pSpokenEditor = scrollNumberEditor("Probability of a reversed card using audio", settings.probSpoken, 0.1, 1.0, 0.1); 
+        reverseDetails.appendChild(pReversedEditor.element);
+        reverseDetails.appendChild(pSpokenEditor.element);
 
         var ssEditor = speechSettingsEditor(settings.speechSettings);
         var ssCont = document.createElement("div")
@@ -285,6 +298,8 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
                 return {
                     doTwoSided: twoSidedEditor.menuToState(),
                     doReadAloud: readAloudEditor.menuToState(),
+                    probReversed: pReversedEditor.menuToState(),
+                    probSpoken: pSpokenEditor.menuToState(), 
                     speechSettings: ssEditor.menuToState(),
                     substitutions: subsEditor.menuToState(),
                     template: tplEditor.menuToState() 
@@ -308,6 +323,8 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         return {
             doTwoSided: true,
             doReadAloud: true,
+            probReversed: 0.5,
+            probSpoken: 0.5,
             speechSettings: defaultSpeechSettings(),
             substitutions: [],
             template: njSimpleCard

--- a/src/core/flashcard-entry.ts
+++ b/src/core/flashcard-entry.ts
@@ -205,9 +205,6 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         var tpl = settings.template;
         var el = <HTMLElement>(new DOMParser().parseFromString(renderString(tpl, templateArgs), "text/html").body.firstChild);
 
-        // a.style.fontSize = `${fontSize}vw`;
-        // a.textContent = prompt;
-        // return new Flashcard(a, hint);
         return new Flashcard(el, hint);
     }
 
@@ -349,6 +346,7 @@ export type ClozeCardSettings = {
     targetLang: string,
     clozeGroups: string[],
     speechSettings: SpeechSettings,
+    template: string
 }
 
 export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, ClozeCardSettings> {
@@ -420,16 +418,26 @@ export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, 
 
     // abstract generateCard(data: D, settings: S, externalParams: IDictionary<any>): Flashcard;
     generateCard(data: ClozeCardData, settings: ClozeCardSettings, externalParams: IDictionary<any> = {}): Flashcard {
-        if (!data.valid) {
-            return renderCard("noanswer-template", `Could not get puzzle for card "${data.key}".`)
+        var fontSize = 5;
+        if (data.valid) {
+            var fontSize = 900.0/(10.0*Math.log(10+data.cloze!.prompt.length)); 
         }
-        var fl = renderCard("cloze-template", {
-            group: data.cloze!.group,
-            guid: "",
-            upper: data.cloze!.prompt,
-            lower: data.cloze!.translation
-        });
-        return fl;
+
+        var prompt = data.cloze!.prompt.replaceAll(/\{\{([^\{\}]+)\}\}/g, ""); 
+
+        var templateArgs = {
+            key: data.key,
+            puzzleFound: data.valid,
+            prompt: prompt, 
+            translation: data.cloze!.translation,
+            source: data.cloze!.group,
+            fontSize: fontSize,
+        };
+        templateArgs = Object.assign({}, templateArgs, externalParams);
+        var tpl = settings.template;
+        var el = <HTMLElement>(new DOMParser().parseFromString(renderString(tpl, templateArgs), "text/html").body.firstChild);
+
+        return new Flashcard(el, data.cloze!.answer);
     }
 
     // abstract checkAnswer(answer: string, data: D, settings: S, tf: (s: string) => string): Promise<boolean>;
@@ -478,6 +486,14 @@ export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, 
         clozeSettingsDiv.appendChild(clozeServerDiv);
         clozeSettingsDiv.appendChild(ssEditor.element);
 
+        var tplDetails = document.createElement("details");
+        var tplSummary = document.createElement("summary");
+        tplSummary.textContent = "Card template";
+        var tplEditor = htmlEditor(settings.template);
+        tplDetails.appendChild(tplSummary);
+        tplDetails.appendChild(tplEditor.element);
+        clozeSettingsDiv.appendChild(tplDetails);
+
         return {
             element: clozeSettingsDiv,
             menuToState: () => {
@@ -486,7 +502,8 @@ export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, 
                     sourceLangs: clozeSourceLangEditor.menuToState().split(','),
                     targetLang: clozeTargetLangEditor.menuToState(),
                     clozeGroups: clozeGroupsEditor.menuToState().split(',').filter((g) => g.length > 0),
-                    speechSettings: ssEditor.menuToState()
+                    speechSettings: ssEditor.menuToState(),
+                    template: tplEditor.menuToState()
                 }
             }
         }
@@ -506,7 +523,8 @@ export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, 
             sourceLangs: [],
             targetLang: "",
             clozeGroups: [],
-            speechSettings: defaultSpeechSettings()
+            speechSettings: defaultSpeechSettings(),
+            template: njClozeCard
         }
     }
 }

--- a/src/core/flashcard-entry.ts
+++ b/src/core/flashcard-entry.ts
@@ -423,7 +423,7 @@ export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, 
             var fontSize = 900.0/(10.0*Math.log(10+data.cloze!.prompt.length)); 
         }
 
-        var prompt = data.cloze!.prompt.replaceAll(/\{\{([^\{\}]+)\}\}/g, ""); 
+        var prompt = data.cloze!.prompt.replaceAll(/\{\{([^\{\}]+)\}\}/g, "___"); 
 
         var templateArgs = {
             key: data.key,

--- a/src/core/flashcard-entry.ts
+++ b/src/core/flashcard-entry.ts
@@ -11,7 +11,9 @@ import {
     swappingTextEditor,
     singleTextFieldEditor,
     multipleEditors,
-    doubleTextFieldEditor
+    doubleTextFieldEditor,
+    textAreaEditor,
+    htmlEditor
 } from "core/editor"
 import {
     TextFilterSettings,
@@ -37,6 +39,13 @@ import {
 import {
     Flashcard
 } from "core/flashcard"
+import {
+    renderString
+} from "nunjucks"
+import {
+    njSimpleCard,
+    njClozeCard
+} from "utils/nj-templates"
 
 export const gCardTypeRegistry: IDictionary<FlashcardType<any, any, any>> = {};
 
@@ -52,7 +61,7 @@ export abstract class FlashcardType<E, D, S> {
     abstract processEntry(entry: E, settings: S, context: any): Promise<D>;
     abstract getSearchableText(entry: E): string;
     abstract getSpeakableText(data: D): string;
-    abstract generateCard(data: D, settings: S): Flashcard;
+    abstract generateCard(data: D, settings: S, externalParams: IDictionary<any>): Flashcard;
     abstract checkAnswer(answer: string, data: D, settings: S, tf: (s: string) => string): Promise<boolean>;
     abstract makeEntryEditor(entry: E): StateEditor<E>;
     abstract makeSettingsEditor(settings: S): StateEditor<S>;
@@ -105,7 +114,8 @@ export type SimpleCardSettings = {
     doTwoSided: boolean,
     doReadAloud: boolean,
     speechSettings: SpeechSettings,
-    substitutions: [string, string][]
+    substitutions: [string, string][],
+    template: string
 }
 
 export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardData, SimpleCardSettings> {
@@ -164,8 +174,8 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
             return data.answer[0];
     }
 
-    // abstract generateCard(data: D, settings: S): Flashcard;
-    generateCard(data: SimpleCardData, settings: SimpleCardSettings): Flashcard {
+    // abstract generateCard(data: D, settings: S, externalParams: IDictionary<any>): Flashcard;
+    generateCard(data: SimpleCardData, settings: SimpleCardSettings, externalParams: IDictionary<any> = {}): Flashcard {
         var a = document.createElement("div");
         var prompt = "";
         var answers: string[] = [];
@@ -184,9 +194,21 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         }
 
         var fontSize = 100.0/(10.0*Math.log(10+prompt.length));
-        a.style.fontSize = `${fontSize}vw`;
-        a.textContent = prompt;
-        return new Flashcard(a, hint);
+        
+        var templateArgs = {
+            prompts: data.prompt,
+            fontSize: fontSize,
+            reversed: data.reversed,
+            spoken: data.spoken
+        };
+        templateArgs = Object.assign({}, templateArgs, externalParams);
+        var tpl = settings.template;
+        var el = <HTMLElement>(new DOMParser().parseFromString(renderString(tpl, templateArgs), "text/html").body.firstChild);
+
+        // a.style.fontSize = `${fontSize}vw`;
+        // a.textContent = prompt;
+        // return new Flashcard(a, hint);
+        return new Flashcard(el, hint);
     }
 
     // abstract checkAnswer(answer: string, data: D, settings: S): Promise<boolean>;
@@ -258,6 +280,14 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         subsEditor.element = hideDetails(subsEditor.element, "Card substitution settings");
         contDiv.appendChild(subsEditor.element);
 
+        var tplDetails = document.createElement("details");
+        var tplSummary = document.createElement("summary");
+        tplSummary.textContent = "Card template";
+        var tplEditor = htmlEditor(settings.template);
+        tplDetails.appendChild(tplSummary);
+        tplDetails.appendChild(tplEditor.element);
+        contDiv.appendChild(tplDetails);
+
         return {
             element: contDiv,
             menuToState: () => {
@@ -265,7 +295,8 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
                     doTwoSided: twoSidedEditor.menuToState(),
                     doReadAloud: readAloudEditor.menuToState(),
                     speechSettings: ssEditor.menuToState(),
-                    substitutions: subsEditor.menuToState()
+                    substitutions: subsEditor.menuToState(),
+                    template: tplEditor.menuToState() 
                 };
             }
         }
@@ -287,7 +318,8 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
             doTwoSided: true,
             doReadAloud: true,
             speechSettings: defaultSpeechSettings(),
-            substitutions: []
+            substitutions: [],
+            template: njSimpleCard
         };
     }
 }
@@ -386,8 +418,8 @@ export class ClozeCardType extends FlashcardType<ClozeCardEntry, ClozeCardData, 
             return "";
     }
 
-    // abstract generateCard(data: D, settings: S): Flashcard;
-    generateCard(data: ClozeCardData, settings: ClozeCardSettings): Flashcard {
+    // abstract generateCard(data: D, settings: S, externalParams: IDictionary<any>): Flashcard;
+    generateCard(data: ClozeCardData, settings: ClozeCardSettings, externalParams: IDictionary<any> = {}): Flashcard {
         if (!data.valid) {
             return renderCard("noanswer-template", `Could not get puzzle for card "${data.key}".`)
         }

--- a/src/core/flashcard-entry.ts
+++ b/src/core/flashcard-entry.ts
@@ -34,7 +34,8 @@ import {
     defaultSpeechSettings,
     speechSettingsEditor,
     SpeechSettings,
-    utter
+    utter,
+    makeAudioButtons
 } from "utils/speech"
 import {
     Flashcard
@@ -181,17 +182,9 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         var answers: string[] = [];
         var hint = "";
         
-        if (data.spoken) {
-            return renderCard("transcript-template", {
-                spokenText: data.prompt[0],
-                hintText: data.answer[0],
-                speechSettings: settings.speechSettings 
-           })
-        } else {
-            prompt = data.prompt[0];
-            answers = data.answer;
-            hint = data.answer[0];
-        }
+        prompt = data.prompt[0];
+        answers = data.answer;
+        hint = data.answer[0];
 
         var fontSize = 100.0/(10.0*Math.log(10+prompt.length));
         
@@ -204,6 +197,7 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         templateArgs = Object.assign({}, templateArgs, externalParams);
         var tpl = settings.template;
         var el = <HTMLElement>(new DOMParser().parseFromString(renderString(tpl, templateArgs), "text/html").body.firstChild);
+        el = makeAudioButtons(el, settings.speechSettings);
 
         return new Flashcard(el, hint);
     }

--- a/src/core/flashcard-template.ts
+++ b/src/core/flashcard-template.ts
@@ -5,6 +5,10 @@ import {
     Flashcard
 } from "core/flashcard"
 
+import {
+    renderString
+} from "nunjucks"
+
 export abstract class FlashcardTemplate<D> {
     abstract getName(): string;
     abstract render(data: D): Flashcard;

--- a/src/decks/spaced-repetition-universal-types.ts
+++ b/src/decks/spaced-repetition-universal-types.ts
@@ -78,14 +78,17 @@ export type SRUniversalCardPhysical = {
     processed?: any,
     context: {
         cardsLeft: number,
-        isPractice: boolean
+        isPractice: boolean,
+        studying: string
     }
 }
 
 export enum SRStudying {
     NewCards = 1,
     DueCards,
-    RandomCards
+    RandomCards,
+    DueThenNewCards,
+    NewThenDueCards
 }
 
 export type SRUniversalSettings = {

--- a/src/decks/spaced-repetition-universal.ts
+++ b/src/decks/spaced-repetition-universal.ts
@@ -445,7 +445,7 @@ export class UniversalSpacedRepGen
         var studyingEditor = radioEditor(
             st.studying,
             [SRStudying.NewCards, SRStudying.DueCards, SRStudying.RandomCards, SRStudying.DueThenNewCards, SRStudying.NewThenDueCards],
-            ["Study new cards", "Study due cards", "Practice random cards", "Study due cards, then new cards", "Study due cards, then new cards"]
+            ["Study new cards", "Study due cards", "Practice random cards", "Study due cards, then new cards", "Study new cards, then due cards"]
         );
         var newQueueSizeEditor = scrollNumberEditor("Max new cards to study at once: ", st.newQ.maxNewCards, 1, 100, 1);
 

--- a/src/decks/spaced-repetition-universal.ts
+++ b/src/decks/spaced-repetition-universal.ts
@@ -290,7 +290,7 @@ export class UniversalSpacedRepGen
         var cardNewState = this.updateCard(card, st, result);
 
         // If card is still new, stick it back in the queue
-        if (st.studying == SRStudying.NewCards) {
+        if (card.context.studying === "new") {
             st.newQ = incorporateLast(st.newQ, cardGuid, this.cardIsNew(cardNewState));
         }
         st.newQ = filterNewQueue(st.newQ, (id: string) => this.cardIsEnabled(st.cards[id], st));
@@ -305,51 +305,63 @@ export class UniversalSpacedRepGen
         var dueInds = this.getDue(st);
         var emptyCard = this.nextCardAsyncPreprocessing({
             virtual: undefined,
-            context: { cardsLeft: 0, isPractice: false }
+            context: { cardsLeft: 0, isPractice: false, studying: "" }
         }, st);
-        switch (st.studying) {
-            case SRStudying.NewCards:
-                var newGuid = chooseNext(st.newQ, newInds);
-                if (newGuid === undefined) {
-                    return emptyCard;     
+
+        if (inds.length == 0) {
+            return emptyCard;
+        }
+
+        if ((st.studying == SRStudying.NewCards) || 
+                (st.studying == SRStudying.NewThenDueCards && newInds.length > 0) ||
+                (st.studying == SRStudying.DueThenNewCards && dueInds.length == 0)) {
+            var newGuid = chooseNext(st.newQ, newInds);
+            if (newGuid === undefined) {
+                return emptyCard;     
+            }
+            return this.nextCardAsyncPreprocessing({
+                virtual: st.cards[newGuid],
+                context: {
+                    cardsLeft: newInds.length,
+                    isPractice: false,
+                    studying: "new"
                 }
-                return this.nextCardAsyncPreprocessing({
-                    virtual: st.cards[newGuid],
-                    context: {
-                        cardsLeft: newInds.length,
-                        isPractice: false
-                    }
-                }, st);
-            case SRStudying.DueCards:
-                if (dueInds.length == 0) {
-                    return emptyCard;
+            }, st);
+        } else if ((st.studying == SRStudying.DueCards) ||
+                    (st.studying == SRStudying.DueThenNewCards) ||
+                    (st.studying == SRStudying.NewThenDueCards && newInds.length == 0)) {
+            if (dueInds.length == 0) {
+                return emptyCard;
+            }
+            var dueInd = dueInds[Math.floor(Math.random() * dueInds.length)];
+            return this.nextCardAsyncPreprocessing({
+                virtual: st.cards[dueInd],
+                context: {
+                    cardsLeft: dueInds.length,
+                    isPractice: false,
+                    studying: "due"
                 }
-                var dueInd = dueInds[Math.floor(Math.random() * dueInds.length)];
-                return this.nextCardAsyncPreprocessing({
-                    virtual: st.cards[dueInd],
-                    context: {
-                        cardsLeft: dueInds.length,
-                        isPractice: false
-                    }
-                }, st);
-            case SRStudying.RandomCards:
-                if (inds.length == 0) {
-                    return emptyCard;
+            }, st);
+        } else if (st.studying == SRStudying.RandomCards) {
+            if (inds.length == 0) {
+                return emptyCard;
+            }
+            var ind = inds[Math.floor(Math.random() * inds.length)];
+            return this.nextCardAsyncPreprocessing({
+                virtual: st.cards[ind],
+                context: {
+                    cardsLeft: 0,
+                    isPractice: true,
+                    studying: "random"
                 }
-                var ind = inds[Math.floor(Math.random() * inds.length)];
-                return this.nextCardAsyncPreprocessing({
-                    virtual: st.cards[ind],
-                    context: {
-                        cardsLeft: 0,
-                        isPractice: true
-                    }
-                }, st); 
+            }, st); 
         }
         return this.nextCardAsyncPreprocessing({
             virtual: undefined,
             context: {
                 cardsLeft: 0,
-                isPractice: false
+                isPractice: false,
+                studying: ""
             }
         }, st);
     }
@@ -405,6 +417,7 @@ export class UniversalSpacedRepGen
         if (card.virtual === undefined || card.processed === undefined) {
             var htmlString = renderString(njNoCardsLeft, {});
             var el = <HTMLElement>(new DOMParser().parseFromString(htmlString, "text/html").body.firstChild);
+            return trivialPromise(new Flashcard(el, ""));
         } 
         
         var cardType = card.virtual!.cardType;
@@ -431,8 +444,8 @@ export class UniversalSpacedRepGen
 
         var studyingEditor = radioEditor(
             st.studying,
-            [SRStudying.NewCards, SRStudying.DueCards, SRStudying.RandomCards],
-            ["Study new cards", "Study due cards", "Practice random cards"]
+            [SRStudying.NewCards, SRStudying.DueCards, SRStudying.RandomCards, SRStudying.DueThenNewCards, SRStudying.NewThenDueCards],
+            ["Study new cards", "Study due cards", "Practice random cards", "Study due cards, then new cards", "Study due cards, then new cards"]
         );
         var newQueueSizeEditor = scrollNumberEditor("Max new cards to study at once: ", st.newQ.maxNewCards, 1, 100, 1);
 

--- a/src/decks/spaced-repetition-universal.ts
+++ b/src/decks/spaced-repetition-universal.ts
@@ -41,8 +41,11 @@ import {
     multipleEditors
 } from "core/editor"
 import {
-    renderCard
-} from "core/flashcard-template"
+    njNoCardsLeft
+} from "utils/nj-templates"
+import {
+    renderString
+} from "nunjucks"
 import {
     registerDeckType
 } from "core/flashcard-deck"
@@ -400,9 +403,8 @@ export class UniversalSpacedRepGen
         card: SRUniversalCardPhysical 
     ): Promise<Flashcard> {
         if (card.virtual === undefined || card.processed === undefined) {
-            return trivialPromise(renderCard("noanswer-template",
-                "No cards left to study."
-            ));
+            var htmlString = renderString(njNoCardsLeft, {});
+            var el = <HTMLElement>(new DOMParser().parseFromString(htmlString, "text/html").body.firstChild);
         } 
         
         var cardType = card.virtual!.cardType;

--- a/src/decks/spaced-repetition-universal.ts
+++ b/src/decks/spaced-repetition-universal.ts
@@ -112,17 +112,6 @@ function makeEmptyCard(cardType: string): SRUniversalCardVirtual {
     }
 }
 
-function makeCardsLeftSpan(card: SRUniversalCardPhysical) {
-    var infoText = document.createElement("span");
-    infoText.classList.add("cards-left-span");
-    if (card.context.isPractice) {  
-        infoText.textContent = "This is a practice card. It will not affect your progress.";
-    } else {
-        infoText.textContent = `${card.context.cardsLeft} cards remaining`;
-    }
-    return infoText;
-}
-
 function infoWidgetSR(
     totalCards: number,
     newCards: number,
@@ -419,8 +408,7 @@ export class UniversalSpacedRepGen
         var cardType = card.virtual!.cardType;
         var cardEntry = card.virtual!.cardEntry;
         var cardProcessed = card.processed;
-        var fl = gCardTypeRegistry[cardType].generateCard(cardProcessed, st.settings.cardTypeSettings[cardType]);
-        fl.el.appendChild(makeCardsLeftSpan(card));
+        var fl = gCardTypeRegistry[cardType].generateCard(cardProcessed, st.settings.cardTypeSettings[cardType], card.context);
         return trivialPromise(fl);
     }
 

--- a/src/decks/uniform-key-value.ts
+++ b/src/decks/uniform-key-value.ts
@@ -78,7 +78,7 @@ var kvDefaultState: KVFlashcardState = {
     deck: [
         ["cat", "gato"],
         ["dog", "perro"],
-        ["el perro runs", "el perro corre"],
+        ["the dog runs", "el perro corre"],
     ],
     history: []
 };

--- a/src/static/style/index.css
+++ b/src/static/style/index.css
@@ -276,7 +276,7 @@ hr {
     right: 0;
 }
 
-.transcription-audio-button {
+.read-aloud-button {
     aspect-ratio: 1;
     width: 100px;
     border-radius: 5px;

--- a/src/utils/nj-templates.ts
+++ b/src/utils/nj-templates.ts
@@ -18,7 +18,7 @@ export const njSimpleCard: string = `\
     {% if isPractice %}
         <span class="cards-left-span">This is a practice card and will not affect progress.</span>
     {% else %}
-        <span class="cards-left-span">{{ cardsLeft }} cards left</span>
+        <span class="cards-left-span">{{ cardsLeft }} {{ studying }} cards left</span>
     {% endif %}
 </div>
 `;
@@ -43,7 +43,7 @@ export const njClozeCard: string = `\
     {% if isPractice %}
     <span class="cards-left-span">This is a practice card and will not affect progress.</span>
     {% else %}
-    <span class="cards-left-span">{{ cardsLeft }} cards left</span>
+    <span class="cards-left-span">{{ cardsLeft }} {{ studying }} cards left</span>
     {% endif %}
 </div>
 `;

--- a/src/utils/nj-templates.ts
+++ b/src/utils/nj-templates.ts
@@ -1,0 +1,29 @@
+import {
+    renderString
+} from "nunjucks"
+
+export const njSimpleCard: string = `\
+<div style="font-size: {{ fontSize }}vw;">
+    {{ prompts[0] }}
+    {% if isPractice %}
+    <span class="cards-left-span">{{ cardsLeft }} cards left</span>
+    {% else %}
+    <span class="cards-left-span">This is a practice card and will not affect progress.</span>
+    {% endif %}
+</div>
+`;
+
+export const njClozeCard: string = `\
+<div style="display: block; text-align: center;">
+    <p style="display: block;">
+        {{ puzzle }}
+    </p>
+    <hr>
+    <p style="display: block;">
+        {{ translation  }}
+    </p>
+    <span>
+        {{ source }}
+    </span>
+</div>
+`;

--- a/src/utils/nj-templates.ts
+++ b/src/utils/nj-templates.ts
@@ -2,6 +2,12 @@ import {
     renderString
 } from "nunjucks"
 
+export const njNoCardsLeft: string = `\
+<div style="font-size: 5vw;">
+   No cards left to study. 
+</div>
+`;
+
 export const njSimpleCard: string = `\
 <div style="font-size: {{ fontSize }}vw;">
     {% if spoken %}

--- a/src/utils/nj-templates.ts
+++ b/src/utils/nj-templates.ts
@@ -21,7 +21,7 @@ export const njClozeCard: string = `\
     </p>
     <hr>
     <p style="display: block;">
-        {{ translation  }}
+        {{ translation }}
     </p>
     <span class="cloze-puzzle-attribution">
         {{ source }}

--- a/src/utils/nj-templates.ts
+++ b/src/utils/nj-templates.ts
@@ -4,11 +4,15 @@ import {
 
 export const njSimpleCard: string = `\
 <div style="font-size: {{ fontSize }}vw;">
-    {{ prompts[0] }}
-    {% if isPractice %}
-    <span class="cards-left-span">This is a practice card and will not affect progress.</span>
+    {% if spoken %}
+        <img src="/speaker.png" class="transcription-audio-button" alt="{{ prompts[0] }}" />
     {% else %}
-    <span class="cards-left-span">{{ cardsLeft }} cards left</span>
+        {{ prompts[0] }}
+    {% endif %}
+    {% if isPractice %}
+        <span class="cards-left-span">This is a practice card and will not affect progress.</span>
+    {% else %}
+        <span class="cards-left-span">{{ cardsLeft }} cards left</span>
     {% endif %}
 </div>
 `;

--- a/src/utils/nj-templates.ts
+++ b/src/utils/nj-templates.ts
@@ -5,7 +5,7 @@ import {
 export const njSimpleCard: string = `\
 <div style="font-size: {{ fontSize }}vw;">
     {% if spoken %}
-        <img src="/speaker.png" class="transcription-audio-button" alt="{{ prompts[0] }}" />
+        <img src="/speaker.png" class="read-aloud-button" alt="{{ prompts[0] }}" />
     {% else %}
         {{ prompts[0] }}
     {% endif %}

--- a/src/utils/nj-templates.ts
+++ b/src/utils/nj-templates.ts
@@ -6,24 +6,34 @@ export const njSimpleCard: string = `\
 <div style="font-size: {{ fontSize }}vw;">
     {{ prompts[0] }}
     {% if isPractice %}
-    <span class="cards-left-span">{{ cardsLeft }} cards left</span>
-    {% else %}
     <span class="cards-left-span">This is a practice card and will not affect progress.</span>
+    {% else %}
+    <span class="cards-left-span">{{ cardsLeft }} cards left</span>
     {% endif %}
 </div>
 `;
 
 export const njClozeCard: string = `\
-<div style="display: block; text-align: center;">
+<div style="display: block; text-align: center; font-size: {{ fontSize }}px;">
+    {% if puzzleFound %}
     <p style="display: block;">
-        {{ puzzle }}
+        {{ prompt }}
     </p>
     <hr>
     <p style="display: block;">
         {{ translation  }}
     </p>
-    <span>
+    <span class="cloze-puzzle-attribution">
         {{ source }}
     </span>
+    {% else %}
+    Could not find cloze puzzle for key "{{ key }}".
+    {% endif %}
+
+    {% if isPractice %}
+    <span class="cards-left-span">This is a practice card and will not affect progress.</span>
+    {% else %}
+    <span class="cards-left-span">{{ cardsLeft }} cards left</span>
+    {% endif %}
 </div>
 `;

--- a/src/utils/speech.ts
+++ b/src/utils/speech.ts
@@ -81,7 +81,7 @@ export function speechSettingsEditor(ss: SpeechSettings): StateEditor<SpeechSett
 }
 
 export function makeAudioButtons(el: HTMLElement, ss: SpeechSettings): HTMLElement {
-    var btns = el.querySelectorAll(".transcription-audio-button");
+    var btns = el.querySelectorAll(".read-aloud-button");
     btns.forEach((btn) => {
         (<any>btn).onclick = (e: any) => {
             utter(e.target.alt, ss.voice, ss.rate, ss.pitch);

--- a/src/utils/speech.ts
+++ b/src/utils/speech.ts
@@ -80,4 +80,16 @@ export function speechSettingsEditor(ss: SpeechSettings): StateEditor<SpeechSett
     }
 }
 
+export function makeAudioButtons(el: HTMLElement, ss: SpeechSettings): HTMLElement {
+    var btns = el.querySelectorAll(".transcription-audio-button");
+    btns.forEach((btn) => {
+        (<any>btn).onclick = (e: any) => {
+            utter(e.target.alt, ss.voice, ss.rate, ss.pitch);
+        }
+    });
+    return el;
+}
+
 // utter("Hello, my name is Albert.", gSynth.getVoices()[0], 1, 1);
+
+


### PR DESCRIPTION
fixes #107
^ it does not move the location of the due/new card radio buttons to the main card editing screen, but rather adds 2 new study settings that make it possible to switch this setting less frequently (see discussion associated with the issue for more info)

fixes #118 
^ templating language "nunjucks" is being used, and HTML templates were added for both currently existing card types

fixes #119 
^ this was an easy fix, adding a few `mkdir -p` lines to the `Makefile`

fixes #121 
^ the probabilities associated with reversed cards and reversed cards with audio are now adjustable in the simple SR card settings, grouped with the global enable/disable checkboxes

Also, tweaked JSON deck exporting to make exported deck files use "pretty formatting". This makes them easier to inspect and edit by hand.