### PR TITLE
Add build CI and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+
+    schedule:
+      interval: "weekly"
+
+    assignees:
+      - "frpzzd"
+      - "altheaden"
+    reviewers:
+      - "frpzzd"
+      - "altheaden"
+

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -1,0 +1,42 @@
+name: CI/CD build workflow
+
+on:
+  push:
+    branches: [develop]
+
+  pull_request:
+    branches: [develop]
+
+  workflow_dispatch:
+
+jobs:
+  build-flashcards:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up conda environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: flashcards-dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+
+      - name: Install dependencies
+        run: |
+          conda install -y --file dev-spec.txt
+          npm install --save @types/jest
+
+      - name: Build flashcards
+        env:
+           CHECK_IMAGES: False
+        run: |
+          make build
+


### PR DESCRIPTION
This PR adds a simple CI workflow which performs the following:

1. creates a conda environment
2. installs dependencies listed in `dev-spec.txt` and `npm` types
3. runs `make build`

The test fails if the build fails. We'll need additional unit testing for non-syntax errors, but this is a basic first test for incoming changes.

This workflow will run anytime there is a PR created that targets `develop`, and should re-run on that PR every time its associated branch is pushed to. It will also run whenever the `develop` branch is either pushed to or merged to. You can also manually trigger this workflow at any time through the Actions tab on GitHub. 

I also added [Dependabot](https://github.com/dependabot), which should check weekly to make sure the dependencies that are used in the GH CI workflows are up-to-date.