### PR TITLE
Display all possible correct answers in hint

### DIFF
--- a/src/core/flashcard-entry.ts
+++ b/src/core/flashcard-entry.ts
@@ -188,7 +188,7 @@ export class SimpleCardType extends FlashcardType<SimpleCardEntry, SimpleCardDat
         
         prompt = data.prompt[0];
         answers = data.answer;
-        hint = data.answer[0];
+        hint = data.answer.join(' | ');
 
         var fontSize = 100.0/(10.0*Math.log(10+prompt.length));
         


### PR DESCRIPTION
Now, when you get a card incorrect, it will display all the possible correct answers in the hint instead of just the first one. The TTS will still only say the first one.

closes #87 